### PR TITLE
Add a Frameworks section with tools that use SoTA papers

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Conference or Journal Year. [[PDF](link)] [[Project](link)] [[Github](link)] [[V
 
 <details><summary>Table of Contents</summary><p>
 
+- [Open Source Frameworks](#open-source-frameworks)
 - [2023](#2023)
 - [2022](#2022)
   * [NeurIPS 2022](#neurips-2022)
@@ -47,6 +48,8 @@ Conference or Journal Year. [[PDF](link)] [[Project](link)] [[Github](link)] [[V
 - [Before 2018](#before-2018)
 </p></details><p></p>
 
+## Open Source Frameworks
+* [joliGEN - An integrated framework for training custom generative AI image-to-image models](https://github.com/jolibrain/joliGEN)
 
 ## 2023
 


### PR DESCRIPTION
Hi, thank you for your great work!

I think it would be nice to also have a **list of tools/frameworks** that use the papers you cite, the first item would be [joliGEN](https://github.com/jolibrain/joliGEN), an integrated framework for training custom generative AI image-to-image models. For example, joliGEN uses SoTA models like [CycleGAN](https://github.com/junyanz/pytorch-CycleGAN-and-pix2pix) or [Palette](https://github.com/Janspiry/Palette-Image-to-Image-Diffusion-Models) for GANs and Diffusion Models, embeds the latest models like [Segment Anything](https://github.com/facebookresearch/segment-anything) or [MobileSAM](https://github.com/ChaoningZhang/MobileSAM) for various applications, and uses the work of everyone at @jolibrain.

- JoliGEN implements both **GAN and Diffusion models** for unpaired and paired image to image translation tasks, including domain and style adaptation with conservation of semantics such as image and object classes, masks, ...

- JoliGEN generative AI capabilities are targeted at real world applications such as **Controled Image Generation**, **Augmented Reality**, **Dataset Smart Augmentation** and object insertion, **Synthetic to Real** transforms.

Thank you for considering our request.
